### PR TITLE
fixed version for Alamofire

### DIFF
--- a/NodeKit.podspec
+++ b/NodeKit.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/surfstudio/NodeKit.git", :tag => "#{s.version}"}
 
   s.source_files  = 'NodeKit/Utils/**/*.swift', 'NodeKit/Chains/**/*.swift', 'NodeKit/Layers/**/*.swift', 'NodeKit/Core/**/*.swift', 'NodeKit/Encodings/*.swift'
-  s.dependency 'Alamofire', '~> 5.0.0-beta.4'
+  s.dependency 'Alamofire', '5.0.0-beta.4'
   s.dependency 'CoreEvents', '~> 1.3.0'
 
 end


### PR DESCRIPTION
Жестко закрепил версию Alamofire, ибо на чистом новом проекте сейчас затягивается версия 5.0.0-rc2, в которой интерфейс поменялся и ничего не собирается в итоге