### PR TITLE
Cancel hotfix

### DIFF
--- a/NodeKit.podspec
+++ b/NodeKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "NodeKit"
-  s.version      = "3.0.0"
+  s.version      = "3.0.0-hotfix-1"
   s.summary      = "Framework for network interaction"
 
   s.homepage     = "https://github.com/surfstudio/NodeKit"

--- a/NodeKit.podspec
+++ b/NodeKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "NodeKit"
-  s.version      = "3.0.0-hotfix-1"
+  s.version      = "3.0.1"
   s.summary      = "Framework for network interaction"
 
   s.homepage     = "https://github.com/surfstudio/NodeKit"

--- a/NodeKit/Core/Supscriptions/Contexts/Context.swift
+++ b/NodeKit/Core/Supscriptions/Contexts/Context.swift
@@ -93,10 +93,13 @@ open class Context<Model>: Observer<Model> {
     }
 
     /// Отмена действия
+    /// - Warning: Затирает всех подписчиков
     @discardableResult
     open override func cancel() -> Self {
         self.cancelClosure?()
         self.deferClosure?()
+        self.completedClosure = nil
+        self.errorClosure = nil
         return self
     }
 

--- a/NodeKit/Core/Supscriptions/Contexts/MulticastContext.swift
+++ b/NodeKit/Core/Supscriptions/Contexts/MulticastContext.swift
@@ -97,10 +97,13 @@ open class MulticastContext<Input>: Observer<Input> {
         return self
     }
 
-    //// Оповещает всех слушателей об отмене.
+    //// Оповещает всех слушателей об отмене
+    /// - Warning: Удаляет всех слушателей!
     @discardableResult
     open override func cancel() -> Self {
         self.eventOnCancelled.invoke(with: ())
+        self.eventOnCompleted.clear()
+        self.eventOnError.clear()
         return self
     }
 


### PR DESCRIPTION
Посыпаю голову пеплом. Оказывается в интеграции отмена запроса не работала. 
Выкатываю хотфикс, который, просто отменяет обработку ответа в случае выполнения cancel.  