### PR TITLE
Use correct dependency versions in SPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "CoreEvents",
         "repositoryURL": "https://github.com/surfstudio/CoreEvents",
         "state": {
-          "branch": "add-swiftpm-support",
-          "revision": "c7c27f0db03c75cd39476e58a0a42ac5e2c66be5",
-          "version": null
+          "branch": null,
+          "revision": "e98f6fea97a1e8a974dbe99156346412de0dfc7a",
+          "version": "2.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire", .exact("5.0.0-beta.6")),
-        .package(url: "https://github.com/surfstudio/CoreEvents", .branch("add-swiftpm-support")),
+        .package(url: "https://github.com/surfstudio/CoreEvents", .exact("2.0.2"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Что сделано?
* После того как добавили Package.swift в CoreEvents билд сломался у всех проектов.
* Изменил на правильную на правильную версию
