### PR TITLE
IDPT-957 NodeKit, обработка системной ошибки с кодом -1020

### DIFF
--- a/NodeKit/Layers/TrasportLayer/TechnicaErrorMapperNode.swift
+++ b/NodeKit/Layers/TrasportLayer/TechnicaErrorMapperNode.swift
@@ -11,10 +11,12 @@ import Foundation
 /// Ошибки для узла `TechnicaErrorMapperNode`
 ///
 /// - noInternetConnection: Возникает в случае, если вернулась системная ошибка об отсутствии соединения.
+/// - dataNotAllowed: Возникает в случае, если вернулась системная ошибка 'kCFURLErrorDataNotAllowed' (предположительная причина - wifi нет, мобильный интернет в целом мог бы быть использован, но выключен. Доки apple крайне скудны в таких объяснениях)
 /// - timeout: Возникает в случае, если превышен лимит ожидания ответа от сервера.
 /// - cantConnectToHost: Возникает в случае, если не удалось установить соединение по конкретному адресу.
 public enum BaseTechnicalError: Error {
     case noInternetConnection
+    case dataNotAllowed
     case timeout
     case cantConnectToHost
 }
@@ -41,6 +43,8 @@ open class TechnicaErrorMapperNode: RequestProcessingLayerNode {
         return self.next.process(data)
             .mapError { error -> Error in
                 switch (error as NSError).code {
+                case -1020:
+                    return BaseTechnicalError.dataNotAllowed
                 case -1009:
                     return BaseTechnicalError.noInternetConnection
                 case -1001:


### PR DESCRIPTION
# Что сделано

- парсинг системного кода ошибки -1020 в один из кейсов `BaseTechnicalError`
- закрывает issue https://github.com/surfstudio/NodeKit/issues/110

# Зачем

- начиная с какого-то времени, предположительно очень давно, допускаю что после выхода 14ой оси, наблюдалось поведение, когда при выключенном wifi при запросе возвращалась не техническая ошибка отсутствия интернета, а нечто другое, что никуда не маппилось и выглядело как просто неопознанная ошибка
- это вместо технического кода -1009 [kCFURLErrorNotConnectedToInternet](https://developer.apple.com/documentation/cfnetwork/cfnetworkerrors/kcfurlerrornotconnectedtointernet?language=objc)
 возвращалась -1020 [kCFURLErrorDataNotAllowed](https://developer.apple.com/documentation/cfnetwork/cfnetworkerrors/kcfurlerrordatanotallowed?language=objc)
- почему - вопрос сложный, ибо доки эпла скудны в этом месте, возможное описание нашел [здесь](https://stackoverflow.com/questions/12925812/reachability-and-international-roaming) - нет wifi, вполне мог бы быть мобильный интернет, но пользователь его выключил, потом dataNotAllowed вместо notInternetConnection

# Как использовать

- на конечных приложениях можно обрабатывать эту ошибку таким же образом, как и простое отсутствие интернета, при необходимости
