### PR TITLE
Добавить сортировку для ключей на алфавитном порядке в запросе

### DIFF
--- a/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
@@ -64,9 +64,9 @@ open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRoute
         }
 
         urlComponents.queryItems = self.config.query
-            .sorted(by: { $0.key < $1.key })
             .map { self.makeQueryComponents(from: $1, by: $0) }
             .reduce([], { $0 + $1 })
+            .sorted(by: { $0.name < $1.name })
 
         guard let newUrl = urlComponents.url else {
             return .emit(error: Error.cantCreateUrlFromUrlComponents)

--- a/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
@@ -64,6 +64,7 @@ open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRoute
         }
 
         urlComponents.queryItems = self.config.query
+            .sorted(by: { $0.key < $1.key })
             .map { self.makeQueryComponents(from: $1, by: $0) }
             .reduce([], { $0 + $1 })
 


### PR DESCRIPTION
# Что сделано

- Добавлена сортировка ключей на алфавитном порядке в запросе

# Зачем

- В проекте столкнулись с проблемой кэширования данных
consultations/list?limit=20&page=1
consultations/list?page=1&limit=20
иногда первым идет limit, а иногда page, а нужно чтобы всегда первым был limit или page, и тогда мы не будем кэшировать один и тот же ответ в две урлы