### PR TITLE
SPT-1998 LoggerContext

### DIFF
--- a/NodeKit.xcodeproj/project.pbxproj
+++ b/NodeKit.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		390E697B2A13660C007F2304 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390E69782A13660C007F2304 /* MultipartFormData.swift */; };
 		390E697C2A13660C007F2304 /* AFError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390E69792A13660C007F2304 /* AFError.swift */; };
 		390E697D2A13660C007F2304 /* HTTPHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390E697A2A13660C007F2304 /* HTTPHeaders.swift */; };
+		502F9D972BAA36CF00151A8D /* LoggingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502F9D962BAA36CF00151A8D /* LoggingContext.swift */; };
+		502F9D9A2BAA389500151A8D /* LoggingContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502F9D992BAA389500151A8D /* LoggingContextTests.swift */; };
+		502F9D9D2BAA39F400151A8D /* Log+Equatalbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502F9D9C2BAA39F400151A8D /* Log+Equatalbe.swift */; };
 		90B608D4283E1110006F4309 /* NodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90B608CB283E1110006F4309 /* NodeKit.framework */; };
 		90B608DA283E1110006F4309 /* NodeKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 90B608CE283E1110006F4309 /* NodeKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90B6090E283E1268006F4309 /* UrlCacheReaderNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B608E4283E1268006F4309 /* UrlCacheReaderNode.swift */; };
@@ -159,6 +162,9 @@
 		390E69782A13660C007F2304 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		390E69792A13660C007F2304 /* AFError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AFError.swift; sourceTree = "<group>"; };
 		390E697A2A13660C007F2304 /* HTTPHeaders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPHeaders.swift; sourceTree = "<group>"; };
+		502F9D962BAA36CF00151A8D /* LoggingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingContext.swift; sourceTree = "<group>"; };
+		502F9D992BAA389500151A8D /* LoggingContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingContextTests.swift; sourceTree = "<group>"; };
+		502F9D9C2BAA39F400151A8D /* Log+Equatalbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Log+Equatalbe.swift"; sourceTree = "<group>"; };
 		90B608CB283E1110006F4309 /* NodeKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NodeKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90B608CE283E1110006F4309 /* NodeKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeKit.h; sourceTree = "<group>"; };
 		90B608D3283E1110006F4309 /* NodeKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NodeKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -343,6 +349,23 @@
 			path = EndToEndTests;
 			sourceTree = "<group>";
 		};
+		502F9D982BAA385E00151A8D /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				502F9D9B2BAA39E700151A8D /* Equatable */,
+				502F9D992BAA389500151A8D /* LoggingContextTests.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		502F9D9B2BAA39E700151A8D /* Equatable */ = {
+			isa = PBXGroup;
+			children = (
+				502F9D9C2BAA39F400151A8D /* Log+Equatalbe.swift */,
+			);
+			path = Equatable;
+			sourceTree = "<group>";
+		};
 		90B608C1283E1110006F4309 = {
 			isa = PBXGroup;
 			children = (
@@ -380,6 +403,7 @@
 		90B608D7283E1110006F4309 /* NodeKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				502F9D982BAA385E00151A8D /* Utils */,
 				39EF561B2A0E28C3004B77C0 /* EndToEndTests */,
 				90B609E2283E16DC006F4309 /* Infrastructure */,
 				90B60A1A283E19C5006F4309 /* Resources */,
@@ -756,6 +780,7 @@
 				90B60980283E1287006F4309 /* Logable.swift */,
 				90B60981283E1287006F4309 /* LoggerExtensions.swift */,
 				90B60982283E1287006F4309 /* Log.swift */,
+				502F9D962BAA36CF00151A8D /* LoggingContext.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -1136,6 +1161,7 @@
 				90B6098D283E1287006F4309 /* Method.swift in Sources */,
 				90B6092B283E1268006F4309 /* Debouncer.swift in Sources */,
 				90B609C2283E1287006F4309 /* MockerProxyConfigNode.swift in Sources */,
+				502F9D972BAA36CF00151A8D /* LoggingContext.swift in Sources */,
 				90B60988283E1287006F4309 /* URLQueryArrayKeyEncodingStartegy.swift in Sources */,
 				390E69752A136591007F2304 /* RequestEncodingModel.swift in Sources */,
 				90B609AF283E1287006F4309 /* RequestCreatorNode.swift in Sources */,
@@ -1175,10 +1201,12 @@
 				90B609F8283E16DC006F4309 /* EncodingTests.swift in Sources */,
 				90B609F1283E16DC006F4309 /* ChainConfiguratorNodeTests.swift in Sources */,
 				90B609F6283E16DC006F4309 /* URLQueryInjectorNodeTests.swift in Sources */,
+				502F9D9A2BAA389500151A8D /* LoggingContextTests.swift in Sources */,
 				90B609FD283E16DC006F4309 /* UrlETagReaderNodeTests.swift in Sources */,
 				90B609F7283E16DC006F4309 /* TokenRefresherNodeTests.swift in Sources */,
 				90B609F4283E16DC006F4309 /* URLQueryArrayKeyEncodingBracketsStartegyTests.swift in Sources */,
 				90B609EF283E16DC006F4309 /* DTOMapperNodeTests.swift in Sources */,
+				502F9D9D2BAA39F400151A8D /* Log+Equatalbe.swift in Sources */,
 				90B60A09283E16DC006F4309 /* AbortingTests.swift in Sources */,
 				90B609FB283E16DC006F4309 /* TestUtls.swift in Sources */,
 				90B60A08283E16DC006F4309 /* Credentials.swift in Sources */,

--- a/NodeKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NodeKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "1d2e6911b0388532b33f83466feee8deadacbc6241719180eb45fd871a5091ac",
   "pins" : [
     {
       "identity" : "coreevents",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/NodeKit/CacheNode/ETag/UrlETagReaderNode.swift
+++ b/NodeKit/CacheNode/ETag/UrlETagReaderNode.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 /// Этот узел читает eTag-токен из хранилища и добавляет его к запросу.
-open class UrlETagReaderNode: TransportLayerNode {
+open class UrlETagReaderNode: Node {
 
     // Следующий узел для обработки.
-    public var next: TransportLayerNode
+    public var next: any TransportLayerNode
 
     /// Ключ, по которому необходимо получить eTag-токен из хедеров.
     /// По-молчанию имеет значение `eTagRequestHeaderKey`
@@ -23,7 +23,7 @@ open class UrlETagReaderNode: TransportLayerNode {
     /// - Parameters:
     ///   - next: Следующий узел для обработки.
     ///   - eTagHeaderKey: Ключ, по которому необходимо добавить eTag-токен к запросу.
-    public init(next: TransportLayerNode,
+    public init(next: some TransportLayerNode,
                 etagHeaderKey: String = ETagConstants.eTagRequestHeaderKey) {
         self.next = next
         self.etagHeaderKey = etagHeaderKey
@@ -31,7 +31,7 @@ open class UrlETagReaderNode: TransportLayerNode {
 
     /// Пытается прочесть eTag-токен из хранилища и добавить его к запросу.
     /// В случае, если прочесть токен не удалось, то управление просто передается дальше.
-    open override func process(_ data: TransportUrlRequest) -> Observer<Json> {
+    open func process(_ data: TransportUrlRequest) -> Observer<Json> {
         guard let tag = UserDefaults.etagStorage?.value(forKey: data.url.absoluteString) as? String else {
             return next.process(data)
         }

--- a/NodeKit/CacheNode/ETag/UrlETagSaverNode.swift
+++ b/NodeKit/CacheNode/ETag/UrlETagSaverNode.swift
@@ -20,10 +20,10 @@ extension UserDefaults {
 
 /// Этот узел сохраняет пришедшие eTag-токены.
 /// В качестве ключа используется абсолютный URL до endpoint-a.
-open class UrlETagSaverNode: ResponsePostprocessorLayerNode {
+open class UrlETagSaverNode: Node {
 
     /// Следующий узел для обработки.
-    public var next: ResponsePostprocessorLayerNode?
+    public var next: (any ResponsePostprocessorLayerNode)?
 
     /// Ключ, по которому необходимо получить eTag-токен из хедеров.
     /// По-молчанию имеет значение `ETagConstants.eTagResponseHeaderKey`
@@ -34,14 +34,14 @@ open class UrlETagSaverNode: ResponsePostprocessorLayerNode {
     /// - Parameters:
     ///   - next: Следующий узел для обработки.
     ///   - eTagHeaderKey: Ключ, по которому необходимо получить eTag-токен из хедеров.
-    public init(next: ResponsePostprocessorLayerNode?, eTagHeaderKey: String = ETagConstants.eTagResponseHeaderKey) {
+    public init(next: (any ResponsePostprocessorLayerNode)?, eTagHeaderKey: String = ETagConstants.eTagResponseHeaderKey) {
         self.next = next
         self.eTagHeaderKey = eTagHeaderKey
     }
 
     /// Пытается получить eTag-токен по ключу `UrlETagSaverNode.eTagHeaderKey`.
     /// В любом случае передает управление дальше.
-    open override func process(_ data: UrlProcessedResponse) -> Observer<Void> {
+    open func process(_ data: UrlProcessedResponse) -> Observer<Void> {
         guard let tag = data.response.allHeaderFields[self.eTagHeaderKey] as? String,
             let url = data.request.url,
             let urlAsKey = url.withOrderedQuery()

--- a/NodeKit/CacheNode/FirstCachePolicyNode.swift
+++ b/NodeKit/CacheNode/FirstCachePolicyNode.swift
@@ -43,8 +43,8 @@ open class FirstCachePolicyNode: Node {
     /// Инициаллизирует узел.
     ///
     /// - Parameters:
-    ///   - cacheReaderNode: Следующий узел для обработки.
-    ///   - next: Узел для чтения из кэша.
+    ///   - cacheReaderNode: Узел для чтения из кэша.
+    ///   - next: Следующий узел для обработки.
     public init(cacheReaderNode: any CacheReaderNode, next: any NextProcessorNode) {
         self.cacheReaderNode = cacheReaderNode
         self.next = next

--- a/NodeKit/CacheNode/FirstCachePolicyNode.swift
+++ b/NodeKit/CacheNode/FirstCachePolicyNode.swift
@@ -20,7 +20,7 @@ public enum BaseFirstCachePolicyNodeError: Error {
 /// Этот узел реализует политику кэширования
 /// "Сначала читаем из кэша, а затем запрашиваем у сервера"
 /// - Important: В ообщем случае слушатель может быть оповещен дважды. Первый раз, когда ответ прочитан из кэша, а второй раз, когда он был получен с сервера.
-open class FirstCachePolicyNode: Node<RawUrlRequest, Json> {
+open class FirstCachePolicyNode: Node {
 
     // MARK: - Nested
 
@@ -33,10 +33,10 @@ open class FirstCachePolicyNode: Node<RawUrlRequest, Json> {
     // MARK: - Properties
 
     /// Следующий узел для обработки.
-    public var next: NextProcessorNode
+    public var next: any NextProcessorNode
 
     /// Узел для чтения из кэша.
-    public var cacheReaderNode: CacheReaderNode
+    public var cacheReaderNode: any CacheReaderNode
 
     // MARK: - Init and Deinit
 
@@ -45,7 +45,7 @@ open class FirstCachePolicyNode: Node<RawUrlRequest, Json> {
     /// - Parameters:
     ///   - cacheReaderNode: Следующий узел для обработки.
     ///   - next: Узел для чтения из кэша.
-    public init(cacheReaderNode: CacheReaderNode, next: NextProcessorNode) {
+    public init(cacheReaderNode: any CacheReaderNode, next: any NextProcessorNode) {
         self.cacheReaderNode = cacheReaderNode
         self.next = next
     }
@@ -56,7 +56,7 @@ open class FirstCachePolicyNode: Node<RawUrlRequest, Json> {
     /// а затем, передает управление следующему узлу.
     /// В случае, если получить `URLRequest` не удалось,
     /// то управление просто передается следующему узлу
-    open override func process(_ data: RawUrlRequest) -> Context<Json> {
+    open func process(_ data: RawUrlRequest) -> Observer<Json> {
         let result = Context<Json>()
 
         if let request = data.toUrlRequest() {

--- a/NodeKit/CacheNode/IfServerFailsFromCacheNode.swift
+++ b/NodeKit/CacheNode/IfServerFailsFromCacheNode.swift
@@ -10,19 +10,19 @@ import Foundation
 
 /// Узел реализует политику кэширования "Если интернета нет, то запросить данные из кэша"
 /// Этот узел работает с URL кэшом.
-open class IfConnectionFailedFromCacheNode: Node<URLRequest, Json> {
+open class IfConnectionFailedFromCacheNode: Node {
 
     /// Следующий узел для обработки.
-    public var next: Node<URLRequest, Json>
+    public var next: any Node<URLRequest, Json>
     /// Узел, считывающий данные из URL кэша.
-    public var cacheReaderNode: Node<UrlNetworkRequest, Json>
+    public var cacheReaderNode: any Node<UrlNetworkRequest, Json>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameters:
     ///   - next: Следующий узел для обработки.
     ///   - cacheReaderNode: Узел, считывающий данные из URL кэша.
-    public init(next: Node<URLRequest, Json>, cacheReaderNode: Node<UrlNetworkRequest, Json>) {
+    public init(next: any Node<URLRequest, Json>, cacheReaderNode: any Node<UrlNetworkRequest, Json>) {
         self.next = next
         self.cacheReaderNode = cacheReaderNode
     }
@@ -30,7 +30,7 @@ open class IfConnectionFailedFromCacheNode: Node<URLRequest, Json> {
     /// Проверяет, произошла ли ошибка связи в ответ на запрос.
     /// Если ошибка произошла, то возвращает успешный ответ из кэша.
     /// В противном случае передает управление следующему узлу.
-    open override func process(_ data: URLRequest) -> Observer<Json> {
+    open func process(_ data: URLRequest) -> Observer<Json> {
 
         return self.next.process(data).mapError { error -> Observer<Json> in
             var logMessage = self.logViewObjectName

--- a/NodeKit/CacheNode/UrlCacheReaderNode.swift
+++ b/NodeKit/CacheNode/UrlCacheReaderNode.swift
@@ -21,8 +21,7 @@ public enum BaseUrlCacheReaderError: Error {
 
 /// Этот узел отвечает за чтение данных из URL кэша.
 /// Сам по себе узел является листом и не может быть встроен в сквозную цепочку.
-open class UrlCacheReaderNode: Node<UrlNetworkRequest, Json> {
-
+open class UrlCacheReaderNode: Node {
 
     public var needsToThrowError: Bool
 
@@ -31,7 +30,7 @@ open class UrlCacheReaderNode: Node<UrlNetworkRequest, Json> {
     }
 
     /// Посылает запрос в кэш и пытается сериализовать данные в JSON.
-    open override func process(_ data: UrlNetworkRequest) -> Context<Json> {
+    open func process(_ data: UrlNetworkRequest) -> Observer<Json> {
 
         guard let cachedResponse = self.extractCachedUrlResponse(data.urlRequest) else {
             return self.needsToThrowError ? .emit(error: BaseUrlCacheReaderError.cantLoadDataFromCache) : Context<Json>()

--- a/NodeKit/CacheNode/UrlCacheWriterNode.swift
+++ b/NodeKit/CacheNode/UrlCacheWriterNode.swift
@@ -12,11 +12,11 @@ import Foundation
 /// - Important: это "глупая" реализация,
 /// в которой не учитываются server-side политики и прочее.
 /// Подразумечается, что этот узел не входит в цепочку, а является листом одного из узлов.
-open class UrlCacheWriterNode: Node<UrlProcessedResponse, Void> {
+open class UrlCacheWriterNode: Node {
 
     /// Формирует `CachedURLResponse` с политикой `.allowed`, сохраняет его в кэш,
     /// а затем возвращает сообщение об успешной операции.
-    open override func process(_ data: UrlProcessedResponse) -> Context<Void> {
+    open func process(_ data: UrlProcessedResponse) -> Observer<Void> {
         let cahced = CachedURLResponse(response: data.response, data: data.data, storagePolicy: .allowed)
         URLCache.shared.storeCachedResponse(cahced, for: data.request)
         return Context<Void>().emit(data: ())

--- a/NodeKit/CacheNode/UrlNotModifiedTriggerNode.swift
+++ b/NodeKit/CacheNode/UrlNotModifiedTriggerNode.swift
@@ -10,15 +10,15 @@ import Foundation
 
 /// Этот узел проверяет код ответа от сервера и в случае, если код равен 304 (NotModified)
 /// Узел посылает запрос в URL кэш.
-open class UrlNotModifiedTriggerNode: ResponseProcessingLayerNode {
+open class UrlNotModifiedTriggerNode: Node {
 
     // MARK: - Properties
 
     /// Следующий узел для обратки.
-    public var next: ResponseProcessingLayerNode
+    public var next: any ResponseProcessingLayerNode
 
     /// Узел для чтения данных из кэша.
-    public var cacheReader: Node<UrlNetworkRequest, Json>
+    public var cacheReader: any Node<UrlNetworkRequest, Json>
 
     // MARK: - Init and deinit
 
@@ -27,8 +27,8 @@ open class UrlNotModifiedTriggerNode: ResponseProcessingLayerNode {
     /// - Parameters:
     ///   - next: Следующий узел для обратки.
     ///   - cacheReader: Узел для чтения данных из кэша.
-    public init(next: ResponseProcessingLayerNode,
-                cacheReader: Node<UrlNetworkRequest, Json>) {
+    public init(next: some ResponseProcessingLayerNode,
+                cacheReader: some Node<UrlNetworkRequest, Json>) {
         self.next = next
         self.cacheReader = cacheReader
     }
@@ -37,7 +37,7 @@ open class UrlNotModifiedTriggerNode: ResponseProcessingLayerNode {
 
     /// Проверяет http status-code. Если код соовуетствует NotModified, то возвращает запрос из кэша.
     /// В протвином случае передает управление дальше.
-    open override func process(_ data: UrlDataResponse) -> Observer<Json> {
+    open func process(_ data: UrlDataResponse) -> Observer<Json> {
 
         var logMessage = self.logViewObjectName
 

--- a/NodeKit/Chains/UrlServiceChainBuilder.swift
+++ b/NodeKit/Chains/UrlServiceChainBuilder.swift
@@ -7,7 +7,7 @@ open class UrlServiceChainBuilder {
     public init() { }
 
     /// Создает цепочку для слоя обработки ответа.
-    open func urlResponseProcessingLayerChain() -> Node<NodeDataResponse, Json> {
+    open func urlResponseProcessingLayerChain() -> any Node<NodeDataResponse, Json> {
         let responseDataParserNode = ResponseDataParserNode()
         let responseDataPreprocessorNode = ResponseDataPreprocessorNode(next: responseDataParserNode)
         let responseHttpErrorProcessorNode = ResponseHttpErrorProcessorNode(next: responseDataPreprocessorNode)
@@ -15,7 +15,7 @@ open class UrlServiceChainBuilder {
     }
 
     /// Создает цепочку узлов, описывающих транспортный слой обработки.
-    open func requestTrasportChain(providers: [MetadataProvider], responseQueue: DispatchQueue, session: URLSession?) -> TransportLayerNode {
+    open func requestTrasportChain(providers: [MetadataProvider], responseQueue: DispatchQueue, session: URLSession?) -> any TransportLayerNode {
         let requestSenderNode = RequestSenderNode(rawResponseProcessor: self.urlResponseProcessingLayerChain(),
                                                   responseQueue: responseQueue,
                                                   manager: session)

--- a/NodeKit/Core/Node/Node.swift
+++ b/NodeKit/Core/Node/Node.swift
@@ -22,7 +22,7 @@ import Foundation
 /// - Отдельный узел для получения ответа
 /// - Отдельный ухел для валидации ответа
 /// Узел может осдержать в себе несколько других узлов, таким образом возможно инкапсулировать цепочку операций над данными. 
-public protocol NodeProtocol {
+public protocol Node<Input, Output> {
 
     /// Тип данных, который узел получает на вход
     associatedtype Input
@@ -34,17 +34,4 @@ public protocol NodeProtocol {
     /// - Parameter data: Входные данные
     /// - Returns: Подписка на процесс обработки данных.
     func process(_ data: Input) -> Observer<Output>
-}
-
-/// Type erasure для `NodeProtocol`
-/// Все узлы необходимо наследовать от этого класса
-/// При наследовании **необходимо** переопределить метод `process(_ data: Input)`
-/// В противном случае при выхове этого метода приложение будет крашится
-open class Node<Input, Output>: NodeProtocol {
-
-    public init() { }
-
-    open func process(_ data: Input) -> Observer<Output> {
-        fatalError("\(self.self) \(#function) must be overriden in subclass")
-    }
 }

--- a/NodeKit/Encodings/UrlJsonRequestEncodingNode.swift
+++ b/NodeKit/Encodings/UrlJsonRequestEncodingNode.swift
@@ -8,20 +8,20 @@
 
 import Foundation
 
-open class UrlJsonRequestEncodingNode<Type>: Node<RequestEncodingModel, Type> {
+open class UrlJsonRequestEncodingNode<Type>: Node {
 
     /// Следующий узел для обработки.
-    public var next: Node<TransportUrlRequest, Type>
+    public var next: any Node<TransportUrlRequest, Type>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameters:
     ///   - next: Следйющий узел для обработки.
-    public init(next: Node<TransportUrlRequest, Type>) {
+    public init(next: some Node<TransportUrlRequest, Type>) {
         self.next = next
     }
 
-    open override func process(_ data: RequestEncodingModel) -> Observer<Type> {
+    open func process(_ data: RequestEncodingModel) -> Observer<Type> {
         var log = getLogMessage(data)
         let request: TransportUrlRequest?
         let paramEncoding = { () -> ParameterEncoding? in

--- a/NodeKit/Layers/ConfigurationLayer/ChainConfiguratorNode.swift
+++ b/NodeKit/Layers/ConfigurationLayer/ChainConfiguratorNode.swift
@@ -5,10 +5,10 @@ import Foundation
 /// Всегда должен быть корневым узлом в графе обработчиков.
 /// Этот узел позволяет установить очередь на которой будет происходит дальнейшая обработк запроса
 /// И очередь на которой обработка будет закончена.
-open class ChainConfiguratorNode<I, O>: Node<I, O> {
+open class ChainConfiguratorNode<I, O>: Node {
 
     /// Следующей узел для обработки.
-    public var next: Node<I, O>
+    public var next: any Node<I, O>
     /// Очерель на которой необходимо выполнить все дальнейшие преобразования.
     public var beginQueue: DispatchQueue
     /// Очередь на которой необходимо выполнить возврат результата работы цепочки.
@@ -20,7 +20,7 @@ open class ChainConfiguratorNode<I, O>: Node<I, O> {
     ///   - next: Следующей узел для обработки.
     ///   - beginQueue: Очерель на которой необходимо выполнить все дальнейшие преобразования.
     ///   - endQueue: Очередь на которой необходимо выполнить возврат результата работы цепочки.
-    public init(next: Node<I, O>, beginQueue: DispatchQueue, endQueue: DispatchQueue) {
+    public init(next: some Node<I, O>, beginQueue: DispatchQueue, endQueue: DispatchQueue) {
         self.next = next
         self.beginQueue = beginQueue
         self.endQueue = endQueue
@@ -32,7 +32,7 @@ open class ChainConfiguratorNode<I, O>: Node<I, O> {
     /// - `endQueue = .main`
     ///
     /// - Parameter next: Следующей узел для обработки.
-    public convenience init(next: Node<I, O>) {
+    public convenience init(next: some Node<I, O>) {
         self.init(next: next, beginQueue: .global(qos: .userInitiated), endQueue: .main)
     }
 
@@ -40,7 +40,7 @@ open class ChainConfiguratorNode<I, O>: Node<I, O> {
     /// затем выполняет всю цепочку операций и диспатчит ответ на `endQueue`
     ///
     /// - Parameter data: Данные для обработки
-    open override func process(_ data: I) -> Observer<O> {
+    open func process(_ data: I) -> Observer<O> {
         return Context<Void>.emit(data: ())
             .dispatchOn(self.beginQueue)
             .map { return self.next.process(data) }

--- a/NodeKit/Layers/DTOProcessingLayer/DTOMapperNode.swift
+++ b/NodeKit/Layers/DTOProcessingLayer/DTOMapperNode.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 /// Этот узел отвечает за маппинг верхнего уровня DTO (`DTOConvertible`) в нижний уровень (`RawMappable`) и наборот.
-open class DTOMapperNode<Input, Output>: Node<Input, Output> where Input: RawEncodable, Output: RawDecodable {
+open class DTOMapperNode<Input, Output>: Node where Input: RawEncodable, Output: RawDecodable {
 
     /// Следующий узел для обрабтки.
-    public var next: Node<Input.Raw, Output.Raw>
+    public var next: any Node<Input.Raw, Output.Raw>
 
     /// Инциаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обрабтки.
-    public init(next: Node<Input.Raw, Output.Raw>) {
+    public init(next: any Node<Input.Raw, Output.Raw>) {
         self.next = next
     }
 
     /// Маппит данные в RawMappable, передает управление следующей цепочке, а затем маппит ответ в DTOConvertible
     ///
     /// - Parameter data: Данные для обработки.
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         let context = Context<Output>()
 
         var log = Log(self.logViewObjectName, id: self.objectName, order: LogOrder.dtoMapperNode)

--- a/NodeKit/Layers/DTOProcessingLayer/RawEncoderNode.swift
+++ b/NodeKit/Layers/DTOProcessingLayer/RawEncoderNode.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 /// Этот узел умеет конвертировать ВХОДНЫЕ данные в RAW, НО не пытается декодировать ответ.
-open class RawEncoderNode<Input, Output>: Node<Input, Output> where Input: RawEncodable {
+open class RawEncoderNode<Input, Output>: Node where Input: RawEncodable {
 
     /// Узел, который умеет работать с RAW
-    open var next: Node<Input.Raw, Output>
+    open var next: any Node<Input.Raw, Output>
 
     /// Инициаллизирует объект
     ///
     /// - Parameter rawEncodable: Узел, который умеет работать с RAW.
-    public init(next: Node<Input.Raw, Output>) {
+    public init(next: some Node<Input.Raw, Output>) {
         self.next = next
     }
 
@@ -25,7 +25,7 @@ open class RawEncoderNode<Input, Output>: Node<Input, Output> where Input: RawEn
     /// Если при конвертирвоании произошла ошибка - прерывает выполнение цепочки.
     ///
     /// - Parameter data: Входящая модель.
-    override open func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         do {
             return next.process(try data.toRaw())
         } catch {

--- a/NodeKit/Layers/InputProcessingLayer/DTOEncoderNode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/DTOEncoderNode.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 /// Этот узел умеет конвертировать ВХОДНЫЕ данные в DTO, НО не пытается декодировать ответ.
-open class DTOEncoderNode<Input, Output>: Node<Input, Output> where Input: DTOEncodable {
+open class DTOEncoderNode<Input, Output>: Node where Input: DTOEncodable {
 
     /// Узел, который умеет работать с DTO
-    open var rawEncodable: Node<Input.DTO, Output>
+    open var rawEncodable: any Node<Input.DTO, Output>
 
     /// Инициаллизирует объект
     ///
     /// - Parameter rawEncodable: Узел, который умеет работать с DTO.
-    public init(rawEncodable: Node<Input.DTO, Output>) {
+    public init(rawEncodable: some Node<Input.DTO, Output>) {
         self.rawEncodable = rawEncodable
     }
 
@@ -25,7 +25,7 @@ open class DTOEncoderNode<Input, Output>: Node<Input, Output> where Input: DTOEn
     /// Если при конвертирвоании произошла ошибка - прерывает выполнение цепочки.
     ///
     /// - Parameter data: Входящая модель.
-    override open func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         do {
             return rawEncodable.process(try data.toDTO())
         } catch {

--- a/NodeKit/Layers/InputProcessingLayer/EntryinputDtoOutputNode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/EntryinputDtoOutputNode.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-open class EntryinputDtoOutputNode<Input, Output>: Node<Input, Output>
+open class EntryinputDtoOutputNode<Input, Output>: Node
                                                     where Input: RawEncodable, Output: DTODecodable {
 
-    open var next: Node<Input.Raw, Output.DTO.Raw>
+    open var next: any Node<Input.Raw, Output.DTO.Raw>
 
-    init(next: Node<Input.Raw, Output.DTO.Raw>) {
+    init(next: any Node<Input.Raw, Output.DTO.Raw>) {
         self.next = next
     }
 
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         do {
             let raw = try data.toRaw()
             return self.next.process(raw).map { try Output.from(dto: Output.DTO.from(raw: $0) ) }

--- a/NodeKit/Layers/InputProcessingLayer/ModelInputNode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/ModelInputNode.swift
@@ -10,15 +10,15 @@ import Foundation
 
 /// Узел для инциаллизации обработки данных.
 /// Иcпользуется для работы с моделями, которые представлены двумя слоями DTO.
-public class ModelInputNode<Input, Output>: Node<Input, Output> where Input: DTOEncodable, Output: DTODecodable {
+public class ModelInputNode<Input, Output>: Node where Input: DTOEncodable, Output: DTODecodable {
 
     /// Следующий узел для обработки.
-    public var next: Node<Input.DTO, Output.DTO>
+    public var next: any Node<Input.DTO, Output.DTO>
 
     /// Инциаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<Input.DTO, Output.DTO>) {
+    public init(next: any Node<Input.DTO, Output.DTO>) {
         self.next = next
     }
 
@@ -27,7 +27,7 @@ public class ModelInputNode<Input, Output>: Node<Input, Output> where Input: DTO
     /// Если при маппинге произошла ошибка, то она будет проброшена выше.
     ///
     /// - Parameter data: Данные для запроса.
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
 
         let context = Context<Output>()
 

--- a/NodeKit/Layers/InputProcessingLayer/VoidIONode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/VoidIONode.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-open class VoidIONode: Node<Void, Void> {
+open class VoidIONode: Node {
 
-    let next: Node<Json, Json>
+    let next: any Node<Json, Json>
 
-    init(next: Node<Json, Json>) {
+    init(next: some Node<Json, Json>) {
         self.next = next
     }
 
-    override open func process(_ data: Void) -> Observer<Void> {
+    open func process(_ data: Void) -> Observer<Void> {
         return self.next.process(Json()).map { json in
             let result = Context<Void>()
             var log = Log(self.logViewObjectName, id: self.objectName, order: LogOrder.voidIONode)

--- a/NodeKit/Layers/InputProcessingLayer/VoidInputNode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/VoidInputNode.swift
@@ -9,20 +9,20 @@
 import Foundation
 
 /// Узел, который позволяет передать на вход `Void`.
-open class VoidInputNode<Output>: Node<Void, Output> {
+open class VoidInputNode<Output>: Node {
 
     /// Следующий узел для обработки.
-    public var next: Node<Json, Output>
+    public var next: any Node<Json, Output>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<Json, Output>) {
+    public init(next: any Node<Json, Output>) {
         self.next = next
     }
 
     /// Передает управление следующему узлу,в качестве параметра передает пустой `Json`
-    open override func process(_ data: Void) -> Observer<Output> {
+    open func process(_ data: Void) -> Observer<Output> {
         return next.process(Json())
     }
 }
@@ -32,7 +32,7 @@ open class VoidInputNode<Output>: Node<Void, Output> {
 /// Содержит иснтаксический сахар для работы с узлами, у которых входящий тип = `Void`
 extension Node where Input == Void {
     /// Вызывает `process(_:)`
-    open func process() -> Observer<Output> {
+    func process() -> Observer<Output> {
         return self.process(Void())
     }
 }

--- a/NodeKit/Layers/InputProcessingLayer/VoidOutputNode.swift
+++ b/NodeKit/Layers/InputProcessingLayer/VoidOutputNode.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-open class VoidOutputNode<Input>: Node<Input, Void> where Input: DTOEncodable, Input.DTO.Raw == Json {
+open class VoidOutputNode<Input>: Node where Input: DTOEncodable, Input.DTO.Raw == Json {
 
-    let next: Node<Json, Json>
+    let next: any Node<Json, Json>
 
-    init(next: Node<Json, Json>) {
+    init(next: some Node<Json, Json>) {
         self.next = next
     }
 
-    override open func process(_ data: Input) -> Observer<Void> {
+    open func process(_ data: Input) -> Observer<Void> {
 
         var newData: Json
 

--- a/NodeKit/Layers/RequestBuildingLayer/MetadataConnectorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/MetadataConnectorNode.swift
@@ -6,10 +6,10 @@ import Foundation
 ///     - `RequestModel`
 ///     - `Node`
 ///     - `RequestRouterNode`
-open class MetadataConnectorNode<Raw, Output>: Node<Raw, Output> {
+open class MetadataConnectorNode<Raw, Output>: Node {
 
     /// Следующий в цепочке узел.
-    public var next: Node<RequestModel<Raw>, Output>
+    public var next: any Node<RequestModel<Raw>, Output>
 
     /// Метаданные для запроса
     public var metadata: [String: String]
@@ -19,7 +19,7 @@ open class MetadataConnectorNode<Raw, Output>: Node<Raw, Output> {
     /// - Parameters:
     ///   - next: Следующий в цепочке узел.
     ///   - metadata: Метаданные для запроса.
-    public init(next: Node<RequestModel<Raw>, Output>, metadata: [String: String]) {
+    public init(next: some Node<RequestModel<Raw>, Output>, metadata: [String: String]) {
         self.next = next
         self.metadata = metadata
     }
@@ -27,7 +27,7 @@ open class MetadataConnectorNode<Raw, Output>: Node<Raw, Output> {
     /// формирует модель `RequestModel` и передает ее на дальнейшую обработку.
     ///
     /// - Parameter data: данные в Raw формате. (после маппинга из Entry)
-    open override func process(_ data: Raw) -> Observer<Output> {
+    open func process(_ data: Raw) -> Observer<Output> {
         return next.process(RequestModel(metadata: self.metadata, raw: data))
     }
 }

--- a/NodeKit/Layers/RequestBuildingLayer/MultipartUrlRequestTrasformatorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/MultipartUrlRequestTrasformatorNode.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// Этот узел переводит Generic запрос в конкретную реализацию.
 /// Данный узел работает с URL-запросами, по HTTP протоколу с JSON
-open class MultipartUrlRequestTrasformatorNode<Type>: Node<RoutableRequestModel<UrlRouteProvider, MultipartModel<[String : Data]>>, Type> {
+open class MultipartUrlRequestTrasformatorNode<Type>: Node {
 
     /// Следйющий узел для обработки.
-    open var next: Node<MultipartUrlRequest, Type>
+    open var next: any Node<MultipartUrlRequest, Type>
 
     /// HTTP метод для запроса.
     open var method: Method
@@ -15,7 +15,7 @@ open class MultipartUrlRequestTrasformatorNode<Type>: Node<RoutableRequestModel<
     /// - Parameters:
     ///   - next: Следйющий узел для обработки.
     ///   - method: HTTP метод для запроса.
-    public init(next: Node<MultipartUrlRequest, Type>, method: Method) {
+    public init(next: any Node<MultipartUrlRequest, Type>, method: Method) {
         self.next = next
         self.method = method
     }
@@ -23,7 +23,9 @@ open class MultipartUrlRequestTrasformatorNode<Type>: Node<RoutableRequestModel<
     /// Конструирует модель для для работы на транспортном уровне цепочки.
     ///
     /// - Parameter data: Данные для дальнейшей обработки.
-    open override func process(_ data: RoutableRequestModel<UrlRouteProvider, MultipartModel<[String : Data]>>) -> Observer<Type> {
+    open func process(
+        _ data: RoutableRequestModel<UrlRouteProvider, MultipartModel<[String : Data]>>
+    ) -> Observer<Type> {
 
         var url: URL
 

--- a/NodeKit/Layers/RequestBuildingLayer/RequestRouterNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/RequestRouterNode.swift
@@ -15,13 +15,13 @@ import Foundation
 ///     - `Node`
 ///     - `MetadataConnectorNode`
 ///     - `RequstEncoderNode`
-open class RequestRouterNode<Raw, Route, Output>: Node<RequestModel<Raw>, Output> {
+open class RequestRouterNode<Raw, Route, Output>: Node {
 
     /// Тип для следующего узла.
     public typealias NextNode = Node<RoutableRequestModel<Route, Raw>, Output>
 
     /// Следующий узел для обработки.
-    public var next: NextNode
+    public var next: any NextNode
 
     /// Маршрут для запроса.
     public var route: Route
@@ -31,13 +31,13 @@ open class RequestRouterNode<Raw, Route, Output>: Node<RequestModel<Raw>, Output
     /// - Parameters:
     ///   - next: Следующий узел для обработки.
     ///   - route: Маршрут для запроса.
-    public init(next: NextNode, route: Route) {
+    public init(next: any NextNode, route: Route) {
         self.next = next
         self.route = route
     }
 
     /// Преобразует `RequestModel` в `RoutableRequestModel` и передает управление следующему узлу
-    open override func process(_ data: RequestModel<Raw>) -> Observer<Output> {
+    open func process(_ data: RequestModel<Raw>) -> Observer<Output> {
         return self.next.process(RoutableRequestModel(metadata: data.metadata, raw: data.raw, route: self.route))
     }
 }

--- a/NodeKit/Layers/RequestBuildingLayer/RequstEncoderNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/RequstEncoderNode.swift
@@ -17,13 +17,13 @@ import Foundation
 ///     - `RequestRouterNode`
 ///     - `EncodableRequestModel`
 ///     - `UrlRequestTrasformatorNode`
-open class RequstEncoderNode<Raw, Route, Encoding, Output>: RequestRouterNode<Raw, Route, Output>.NextNode {
+open class RequstEncoderNode<Raw, Route, Encoding, Output>: Node {
 
     /// Тип для следюущего узла.
     public typealias NextNode = Node<EncodableRequestModel<Route, Raw, Encoding>, Output>
 
     /// Следюущий узел для обработки.
-    public var next: NextNode
+    public var next: any NextNode
 
     /// Кодировка для запроса.
     public var encoding: Encoding?
@@ -33,14 +33,14 @@ open class RequstEncoderNode<Raw, Route, Encoding, Output>: RequestRouterNode<Ra
     /// - Parameters:
     ///   - next: Следюущий узел для обработки.
     ///   - encoding: Кодировка для запроса.
-    public init(next: NextNode, encoding: Encoding) {
+    public init(next: some NextNode, encoding: Encoding) {
         self.next = next
         self.encoding = encoding
     }
 
     /// Преобразует `RoutableRequestModel` в `EncodableRequestModel`
     /// и передает управление следующему узлу.
-    open override func process(_ data: RoutableRequestModel<Route, Raw>) -> Observer<Output> {
+    open func process(_ data: RoutableRequestModel<Route, Raw>) -> Observer<Output> {
         let model = EncodableRequestModel(metadata: data.metadata, raw: data.raw, route: data.route, encoding: self.encoding)
         return self.next.process(model)
     }

--- a/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/URLQueryInjectorNode.swift
@@ -15,7 +15,7 @@ public enum URLQueryInjectorNodeError: Error {
 ///
 /// - Info:
 /// Использовать можно после `RequestRouterNode`.
-open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRouteProvider, Raw>, Output> {
+open class URLQueryInjectorNode<Raw, Output>: Node {
 
     // MARK: - Nested
 
@@ -25,7 +25,7 @@ open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRoute
     // MARK: - Properties
 
     /// Следующий по порядку узел.
-    open var next: Node<RoutableRequestModel<UrlRouteProvider, Raw>, Output>
+    open var next: any Node<RoutableRequestModel<UrlRouteProvider, Raw>, Output>
 
     open var config: URLQueryConfigModel
 
@@ -34,8 +34,10 @@ open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRoute
     /// Инцииаллизирует объект.
     /// - Parameter next: Следующий по порядку узел.
     /// - Parameter config: Конфигурация для узла.
-    public init(next: Node<RoutableRequestModel<UrlRouteProvider, Raw>, Output>, config: URLQueryConfigModel) {
-
+    public init(
+        next: any Node<RoutableRequestModel<UrlRouteProvider, Raw>, Output>,
+        config: URLQueryConfigModel
+    ) {
         self.next = next
         self.config = config
     }
@@ -45,7 +47,7 @@ open class URLQueryInjectorNode<Raw, Output>: Node<RoutableRequestModel<UrlRoute
     /// Добавляет URL-query если может и передает управление следующему узлу.
     /// В случае, если не удалось обработать URL, то возвращает ошибку `cantCreateUrlComponentsFromUrlString`
     /// - SeeAlso: `URLQueryInjectorNodeError`
-    open override func process(_ data: RoutableRequestModel<UrlRouteProvider, Raw>) -> Observer<Output> {
+    open func process(_ data: RoutableRequestModel<UrlRouteProvider, Raw>) -> Observer<Output> {
 
         guard !self.config.query.isEmpty else {
             return self.next.process(data)

--- a/NodeKit/Layers/RequestBuildingLayer/UrlRequestTrasformatorNode.swift
+++ b/NodeKit/Layers/RequestBuildingLayer/UrlRequestTrasformatorNode.swift
@@ -6,10 +6,10 @@ enum RequestEncodingError: Error {
 
 /// Этот узел переводит Generic запрос в конкретную реализацию.
 /// Данный узел работает с URL-запросами, по HTTP протоколу с JSON
-open class UrlRequestTrasformatorNode<Type>: Node<EncodableRequestModel<UrlRouteProvider, Json, ParametersEncoding?>, Type> {
+open class UrlRequestTrasformatorNode<Type>: Node {
 
     /// Следйющий узел для обработки.
-    public var next: Node<RequestEncodingModel, Type>
+    public var next: any Node<RequestEncodingModel, Type>
 
     /// HTTP метод для запроса.
     public var method: Method
@@ -19,7 +19,7 @@ open class UrlRequestTrasformatorNode<Type>: Node<EncodableRequestModel<UrlRoute
     /// - Parameters:
     ///   - next: Следйющий узел для обработки.
     ///   - method: HTTP метод для запроса.
-    public init(next: Node<RequestEncodingModel, Type>, method: Method) {
+    public init(next: some Node<RequestEncodingModel, Type>, method: Method) {
         self.next = next
         self.method = method
     }
@@ -27,7 +27,9 @@ open class UrlRequestTrasformatorNode<Type>: Node<EncodableRequestModel<UrlRoute
     /// Конструирует модель для для работы на транспортном уровне цепочки.
     ///
     /// - Parameter data: Данные для дальнейшей обработки.
-    open override func process(_ data: EncodableRequestModel<UrlRouteProvider, Json, ParametersEncoding?>) -> Observer<Type> {
+    open func process(
+        _ data: EncodableRequestModel<UrlRouteProvider, Json, ParametersEncoding?>
+    ) -> Observer<Type> {
 
         var url: URL
 

--- a/NodeKit/Layers/RequestProcessingLayer/MultipartRequestCreatorNode.swift
+++ b/NodeKit/Layers/RequestProcessingLayer/MultipartRequestCreatorNode.swift
@@ -24,21 +24,21 @@ public struct MultipartUrlRequest {
 }
 
 /// Узел, умеющий создавать multipart-запрос.
-open class MultipartRequestCreatorNode<Output>: Node<MultipartUrlRequest, Output> {
+open class MultipartRequestCreatorNode<Output>: Node {
     /// Следующий узел для обработки.
-    public var next: Node<URLRequest, Output>
+    public var next: any Node<URLRequest, Output>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<URLRequest, Output>) {
+    public init(next: any Node<URLRequest, Output>) {
         self.next = next
     }
 
     /// Конфигурирует низкоуровненвый запрос.
     ///
     /// - Parameter data: Данные для конфигурирования и последующей отправки запроса.
-    open override func process(_ data: MultipartUrlRequest) -> Observer<Output> {
+    open func process(_ data: MultipartUrlRequest) -> Observer<Output> {
         do {
             var request = URLRequest(url: data.url)
             request.httpMethod = data.method.rawValue

--- a/NodeKit/Layers/RequestProcessingLayer/RequestCreatorNode.swift
+++ b/NodeKit/Layers/RequestProcessingLayer/RequestCreatorNode.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 /// Этот узел инициаллизирует URL запрос.
-open class RequestCreatorNode<Output>: Node<TransportUrlRequest, Output> {
+open class RequestCreatorNode<Output>: Node {
 
     /// Следующий узел для обработки.
-    public var next: Node<URLRequest, Output>
+    public var next: any Node<URLRequest, Output>
 
     /// Провайдеры мета-данных
     public var providers: [MetadataProvider]
@@ -12,7 +12,7 @@ open class RequestCreatorNode<Output>: Node<TransportUrlRequest, Output> {
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<URLRequest, Output>, providers: [MetadataProvider] = []) {
+    public init(next: some Node<URLRequest, Output>, providers: [MetadataProvider] = []) {
         self.next = next
         self.providers = providers
     }
@@ -20,7 +20,7 @@ open class RequestCreatorNode<Output>: Node<TransportUrlRequest, Output> {
     /// Конфигурирует низкоуровненвый запрос.
     ///
     /// - Parameter data: Данные для конфигурирования и последующей отправки запроса.
-    open override func process(_ data: TransportUrlRequest) -> Observer<Output> {
+    open func process(_ data: TransportUrlRequest) -> Observer<Output> {
         var mergedHeaders = data.headers
 
         self.providers.map { $0.metadata() }.forEach { dict in

--- a/NodeKit/Layers/RequestProcessingLayer/RequestSenderNode.swift
+++ b/NodeKit/Layers/RequestProcessingLayer/RequestSenderNode.swift
@@ -16,13 +16,13 @@ public struct NodeDataResponse {
 
 /// Этот узел отправляет запрос на сервер и ожидает ответ.
 /// - Important: этот узел имеет состояние (statefull)
-open class RequestSenderNode<Type>: Node<URLRequest, Type>, Aborter {
+open class RequestSenderNode<Type>: Node, Aborter {
 
     /// Тип для узла, который будет обрабатывать ответ от сервера.
     public typealias RawResponseProcessor = Node<NodeDataResponse, Type>
 
     /// Узел для обработки ответа.
-    public var rawResponseProcessor: RawResponseProcessor
+    public var rawResponseProcessor: any RawResponseProcessor
 
     /// Менеджер сессий
     private(set) var manager: URLSession
@@ -38,7 +38,7 @@ open class RequestSenderNode<Type>: Node<URLRequest, Type>, Aborter {
     /// - Parameter responseQueue: Очередь, на которой будет выполнен ответ
     /// - Parameter manager: URLSession менеджер, по умолчанию задается сессия из ServerRequestsManager
     public init(
-        rawResponseProcessor: RawResponseProcessor,
+        rawResponseProcessor: some RawResponseProcessor,
         responseQueue: DispatchQueue,
         manager: URLSession? = nil
     ) {
@@ -50,7 +50,7 @@ open class RequestSenderNode<Type>: Node<URLRequest, Type>, Aborter {
     /// Выполняет запрос,ожидает ответ и передает его следующему узлу.
     ///
     /// - Parameter request: Данные для исполнения запроса.
-    open override func process(_ request: URLRequest) -> Observer<Type> {
+    open func process(_ request: URLRequest) -> Observer<Type> {
 
         let context = Context<NodeDataResponse>()
         self.context = context

--- a/NodeKit/Layers/ResponseProcessingLayer/DataLoading/DataLoadingResponseProcessor.swift
+++ b/NodeKit/Layers/ResponseProcessingLayer/DataLoading/DataLoadingResponseProcessor.swift
@@ -12,20 +12,20 @@ import Foundation
 /// Должен использоваться для тех случаях, когда конвертирование в JSON не нужно или не возможно (например загрузка картинок)
 /// Содержит указание на следующий узел, который нужен для постобработки.
 /// Например может использоваться для сохранения.
-open class DataLoadingResponseProcessor: Node<UrlDataResponse, Data> {
+open class DataLoadingResponseProcessor: Node {
 
     /// Узел для постобработки загруженных данных.
-    open var next: Node<UrlDataResponse, Void>?
+    open var next: (any Node<UrlDataResponse, Void>)?
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Узел для постобработки загруженных данных. По-умолчанию nil.
-    public init(next: Node<UrlDataResponse, Void>? = nil) {
+    public init(next: (any Node<UrlDataResponse, Void>)? = nil) {
         self.next = next
     }
 
     /// В случае, если узел для постобработки существует, то вызывает его, если нет - возвращает данные.
-    override open func process(_ data: UrlDataResponse) -> Observer<Data> {
+    open func process(_ data: UrlDataResponse) -> Observer<Data> {
         guard let next = self.next else {
             return .emit(data: data.data)
         }

--- a/NodeKit/Layers/ResponseProcessingLayer/ResponseDataParserNode.swift
+++ b/NodeKit/Layers/ResponseProcessingLayer/ResponseDataParserNode.swift
@@ -19,22 +19,22 @@ public enum ResponseDataParserNodeError: Error {
 
 /// Выполняет преобразование преобразование "сырых" данных в `Json`
 /// - SeeAlso: `MappingUtils`
-open class ResponseDataParserNode: Node<UrlDataResponse, Json> {
+open class ResponseDataParserNode: Node {
 
     /// Следующий узел для обработки.
-    public var next: ResponsePostprocessorLayerNode?
+    public var next: (any ResponsePostprocessorLayerNode)?
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: ResponsePostprocessorLayerNode? = nil) {
+    public init(next: (any ResponsePostprocessorLayerNode)? = nil) {
         self.next = next
     }
 
     /// Парсит ответ и в случае успеха передает управление следующему узлу.
     ///
     /// - Parameter data: Модель овтета сервера.
-    open override func process(_ data: UrlDataResponse) -> Observer<Json> {
+    open func process(_ data: UrlDataResponse) -> Observer<Json> {
 
         let context = Context<Json>()
         var json = Json()

--- a/NodeKit/Layers/ResponseProcessingLayer/ResponseDataPreprocessorNode.swift
+++ b/NodeKit/Layers/ResponseProcessingLayer/ResponseDataPreprocessorNode.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// Этот узел занимается десериализаций данных ответа в `JSON`.
 /// В случае 204-го ответа далее передает пустой `Json`.
-open class ResponseDataPreprocessorNode: ResponseProcessingLayerNode {
+open class ResponseDataPreprocessorNode: Node {
 
     /// Следующий узел для обработки.
-    public var next: ResponseProcessingLayerNode
+    public var next: any ResponseProcessingLayerNode
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: ResponseProcessingLayerNode) {
+    public init(next: some ResponseProcessingLayerNode) {
         self.next = next
     }
 
     /// Сериализует "сырые" данные в `Json`
     ///
     /// - Parameter data: Представление ответа.
-    open override func process(_ data: UrlDataResponse) -> Observer<Json> {
+    open func process(_ data: UrlDataResponse) -> Observer<Json> {
         var log = Log(self.logViewObjectName, id: self.objectName, order: LogOrder.responseDataPreprocessorNode)
 
         guard data.response.statusCode != 204 else {

--- a/NodeKit/Layers/ResponseProcessingLayer/ResponseHttpErrorProcessorNode.swift
+++ b/NodeKit/Layers/ResponseProcessingLayer/ResponseHttpErrorProcessorNode.swift
@@ -26,17 +26,17 @@ public enum ResponseHttpErrorProcessorNodeError: Error {
 /// Этот узел обрабатывает ответ сервера и в случае статус кодов,
 /// которые соответствуют ошибкам, перечисленным в `ResponseHttpErrorProcessorNodeError`
 /// В случае, если коды не совпали в необходимыми,то управление переходит следующему узлу.
-open class ResponseHttpErrorProcessorNode<Type>: Node<UrlDataResponse, Type> {
+open class ResponseHttpErrorProcessorNode<Type>: Node {
 
     public typealias HttpError = ResponseHttpErrorProcessorNodeError
 
     /// Следующий узел для обработки.
-    public var next: Node<UrlDataResponse, Type>
+    public var next: any Node<UrlDataResponse, Type>
 
     /// Инициаллизирует объект.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<UrlDataResponse, Type>) {
+    public init(next: some Node<UrlDataResponse, Type>) {
         self.next = next
     }
 
@@ -44,7 +44,7 @@ open class ResponseHttpErrorProcessorNode<Type>: Node<UrlDataResponse, Type> {
     /// В противном случае возвращает `HttpError`
     ///
     /// - Parameter data: Модель ответа сервера.
-    open override func process(_ data: UrlDataResponse) -> Observer<Type> {
+    open func process(_ data: UrlDataResponse) -> Observer<Type> {
 
         let context = Context<Type>()
 

--- a/NodeKit/Layers/ResponseProcessingLayer/ResponseProcessorNode.swift
+++ b/NodeKit/Layers/ResponseProcessingLayer/ResponseProcessorNode.swift
@@ -16,22 +16,22 @@ public enum ResponseProcessorNodeError: Error {
 }
 
 /// Этот узел занимается первичной обработкой ответа сервера.
-open class ResponseProcessorNode<Type>: Node<NodeDataResponse, Type> {
+open class ResponseProcessorNode<Type>: Node {
 
     /// Следующий узел для обратки.
-    public let next: Node<UrlDataResponse, Type>
+    public let next: any Node<UrlDataResponse, Type>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обратки.
-    public init(next: Node<UrlDataResponse, Type>) {
+    public init(next: some Node<UrlDataResponse, Type>) {
         self.next = next
     }
 
     /// Проверяет, возникла-ли какая-то ошибка во время работы.
     ///
     /// - Parameter data: Низкоуровневый ответ сервера.
-    open override func process(_ data: NodeDataResponse) -> Observer<Type> {
+    open func process(_ data: NodeDataResponse) -> Observer<Type> {
         var log = Log(self.logViewObjectName, id: self.objectName, order: LogOrder.responseProcessorNode)
 
         switch data.result {

--- a/NodeKit/Layers/TrasportLayer/TechnicaErrorMapperNode.swift
+++ b/NodeKit/Layers/TrasportLayer/TechnicaErrorMapperNode.swift
@@ -24,22 +24,22 @@ public enum BaseTechnicalError: Error {
 /// Этот узел заниматеся маппингом технических ошибок
 /// (ошибок уровня ОС)
 /// - SeeAlso: `BaseTechnicalError`
-open class TechnicaErrorMapperNode: Node<URLRequest, Json> {
+open class TechnicaErrorMapperNode: Node {
 
     /// Следующий узел для обработки.
-    open var next: Node<URLRequest, Json>
+    open var next: any Node<URLRequest, Json>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameter next: Следующий узел для обработки.
-    public init(next: Node<URLRequest, Json>) {
+    public init(next: any Node<URLRequest, Json>) {
         self.next = next
     }
 
     /// Передает управление следующему узлу, и в случае ошибки маппит ее.
     ///
     /// - Parameter data: Данные для обработки.
-    open override func process(_ data: URLRequest) -> Observer<Json> {
+    open func process(_ data: URLRequest) -> Observer<Json> {
         return self.next.process(data)
             .mapError { error -> Error in
                 switch (error as NSError).code {

--- a/NodeKit/Layers/Utils/AccessSafe/AccessSafeNode.swift
+++ b/NodeKit/Layers/Utils/AccessSafe/AccessSafeNode.swift
@@ -47,29 +47,29 @@ public enum AccessSafeNodeError: Error {
 /// - SeeAlso:
 ///     - `TransportLayerNode`
 ///     - `TokenRefresherNode`
-open class AccessSafeNode: TransportLayerNode {
+open class AccessSafeNode: Node {
 
     /// Следующий в цепочке узел.
-    public var next: TransportLayerNode
+    public var next: any TransportLayerNode
 
     /// Цепочка для обновления токена.
     /// Эта цепочкаа в самом начале должна выключать узел, который имплементирует заморозку запросов и их возобновление.
     /// Из-коробки это реализует узел `TokenRefresherNode`
-    public var updateTokenChain: Node<Void, Void>
+    public var updateTokenChain: any Node<Void, Void>
 
     /// Инициаллизирует узел.
     ///
     /// - Parameters:
     ///   - next: Следующий в цепочке узел.
     ///   - updateTokenChain: Цепочка для обновления токена.
-    public init(next: TransportLayerNode, updateTokenChain: Node<Void, Void>) {
+    public init(next: some TransportLayerNode, updateTokenChain: some Node<Void, Void>) {
         self.next = next
         self.updateTokenChain = updateTokenChain
     }
 
     /// Просто передает управление следующему узлу.
     /// В случае если вернулась доступа, то обноляет токен и повторяет запрос.
-    override open func process(_ data: TransportUrlRequest) -> Observer<Json> {
+    open func process(_ data: TransportUrlRequest) -> Observer<Json> {
         return self.next.process(data).mapError { error -> Observer<Json> in
             switch error {
             case ResponseHttpErrorProcessorNodeError.forbidden, ResponseHttpErrorProcessorNodeError.unauthorized:

--- a/NodeKit/Layers/Utils/AccessSafe/TokenRefresherNode.swift
+++ b/NodeKit/Layers/Utils/AccessSafe/TokenRefresherNode.swift
@@ -11,10 +11,10 @@ import Foundation
 /// Узел для обновления токена и заморозки запросов.
 /// Внутри себя работает на приватных очередях.
 /// Ответ возращает в той очереди, из которой узел был вызыван.
-open class TokenRefresherNode: Node<Void, Void> {
+open class TokenRefresherNode: Node {
 
     /// Цепочка для обновления токена.
-    public var tokenRefreshChain: Node<Void, Void>
+    public var tokenRefreshChain: any Node<Void, Void>
 
     private var isRequestSended = false
     private var observers: [Context<Void>]
@@ -25,7 +25,7 @@ open class TokenRefresherNode: Node<Void, Void> {
     /// Иницицаллизирует
     ///
     /// - Parameter tokenRefreshChain: Цепочка для обновления токена.
-    public init(tokenRefreshChain: Node<Void, Void>) {
+    public init(tokenRefreshChain: any Node<Void, Void>) {
         self.tokenRefreshChain = tokenRefreshChain
         self.observers = []
     }
@@ -34,7 +34,7 @@ open class TokenRefresherNode: Node<Void, Void> {
     /// Если запрос был отправлен, то создает `Observer`, сохраняет его у себя и возвращает предыдущему узлу.
     /// Если нет - отплавляет запрос и сохраняет `Observer`
     /// После того как запрос на обновление токена был выполнен успешно - эмитит данные во все сохраненные Observer'ы и удаляет их из памяти
-    open override func process(_ data: Void) -> Observer<Void> {
+    open func process(_ data: Void) -> Observer<Void> {
 
         let shouldSaveContext: Bool = self.flagQueue.sync {
             if self.isRequestSended {

--- a/NodeKit/Layers/Utils/HeaderInjectorNode.swift
+++ b/NodeKit/Layers/Utils/HeaderInjectorNode.swift
@@ -11,10 +11,10 @@ import Foundation
 
 /// Этот узел позволяет добавить любые хедеры в запрос.
 /// - SeeAlso: TransportLayerNode
-open class HeaderInjectorNode: TransportLayerNode {
+open class HeaderInjectorNode: Node {
 
     /// Следующий в цепочке узел.
-    public var next: TransportLayerNode
+    public var next: any TransportLayerNode
 
     /// Хедеры, которые необходимо добавить.
     public var headers: [String: String]
@@ -24,13 +24,13 @@ open class HeaderInjectorNode: TransportLayerNode {
     /// - Parameters:
     ///   - next: Следующий в цепочке узел.
     ///   - headers: Хедеры, которые необходимо добавить.
-    public init(next: TransportLayerNode, headers: [String: String]) {
+    public init(next: some TransportLayerNode, headers: [String: String]) {
         self.next = next
         self.headers = headers
     }
 
     /// Добавляет хедеры к запросу и отправляет его слудующему в цепочке узлу.
-    open override func process(_ data: TransportUrlRequest) -> Observer<Json> {
+    open func process(_ data: TransportUrlRequest) -> Observer<Json> {
         var resultHeaders = self.headers
         var log = self.logViewObjectName
         log += "Add headers \(self.headers)" + .lineTabDeilimeter

--- a/NodeKit/Layers/Utils/LoadIndicatorNode.swift
+++ b/NodeKit/Layers/Utils/LoadIndicatorNode.swift
@@ -24,21 +24,21 @@ private enum LoadIndicatableNodeStatic {
 }
 
 /// Показыает спиннер загрзки в статус-баре.
-open class LoadIndicatableNode<Input, Output>: Node<Input, Output> {
+open class LoadIndicatableNode<Input, Output>: Node {
 
     /// Следующий узел в цепочке.
-    open var next: Node<Input, Output>
+    open var next: any Node<Input, Output>
 
     /// Инциаллизирует узел.
     ///
     /// - Parameter next: Следующий узел в цепочке.
-    public init(next: Node<Input, Output> ) {
+    public init(next: some Node<Input, Output> ) {
         self.next = next
     }
 
     /// Показывает индикатор и передает управление дальше.
     /// По окнчании работы цепочки скрывает индикатор.
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         DispatchQueue.global().async(flags: .barrier) {
             LoadIndicatableNodeStatic.requestConter += 1
         }

--- a/NodeKit/Layers/Utils/RequestAborterNode.swift
+++ b/NodeKit/Layers/Utils/RequestAborterNode.swift
@@ -21,10 +21,10 @@ public protocol Aborter {
 /// - SeeAlso:
 ///     - `Aborter`
 ///     - `Node`
-open class AborterNode<Input, Output>: Node<Input, Output> {
+open class AborterNode<Input, Output>: Node {
 
     /// Следюущий в цепочке узел
-    public var next: Node<Input, Output>
+    public var next: any Node<Input, Output>
 
     /// Сущность, отменяющая преобразование
     public var aborter: Aborter
@@ -34,14 +34,14 @@ open class AborterNode<Input, Output>: Node<Input, Output> {
     /// - Parameters:
     ///   - next: Следюущий в цепочке узел
     ///   - aborter: Сущность, отменяющая преобразование
-    public init(next: Node<Input, Output>, aborter: Aborter) {
+    public init(next: any Node<Input, Output>, aborter: Aborter) {
         self.next = next
         self.aborter = aborter
     }
 
     /// Просто передает поток следующему узлу
     /// и если пришло сообщение об отмене запроса, то посылает Aborter'у `cancel()`
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         return self.next.process(data)
             .multicast()
             .onCanceled { [weak self] in

--- a/NodeKit/MockerIntegration/MockerProxyConfigNode.swift
+++ b/NodeKit/MockerIntegration/MockerProxyConfigNode.swift
@@ -16,14 +16,14 @@ public enum MockerProxyConfigKey {
 /// - SeeAlso:
 ///     - `MetadataConnectorNode`
 ///     - `RequestRouterNode`
-final class MockerProxyConfigNode<Raw, Output>: Node<RequestModel<Raw>, Output> {
+final class MockerProxyConfigNode<Raw, Output>: Node {
 
     private typealias Keys = MockerProxyConfigKey
 
     // MARK: - Public Properties
 
     /// Следующий в цепочке узел.
-    public var next: Node<RequestModel<Raw>, Output>
+    public var next: any Node<RequestModel<Raw>, Output>
 
     /// Указывает, включено ли проексирование.
     public var isProxyingOn: Bool
@@ -41,7 +41,7 @@ final class MockerProxyConfigNode<Raw, Output>: Node<RequestModel<Raw>, Output> 
     ///   - isProxyingOn: Указывает, включено ли проексирование.
     ///   - proxyingHost: Адрес хоста (опционально с портом) которому будет переадресован запрос.
     ///   - proxyingSchema: Схема (http/https etc).
-    public init(next: Node<RequestModel<Raw>, Output>,
+    public init(next: any Node<RequestModel<Raw>, Output>,
                 isProxyingOn: Bool,
                 proxyingHost: String = "",
                 proxyingScheme: String = "") {
@@ -54,7 +54,7 @@ final class MockerProxyConfigNode<Raw, Output>: Node<RequestModel<Raw>, Output> 
     // MARK: - Node
 
     /// Добавляет хедеры в `data`
-    override func process(_ data: RequestModel<Raw>) -> Observer<Output> {
+    public func process(_ data: RequestModel<Raw>) -> Observer<Output> {
 
         guard self.isProxyingOn else {
             return self.next.process(data)

--- a/NodeKit/MockerIntegration/MockerProxyConfigNode.swift
+++ b/NodeKit/MockerIntegration/MockerProxyConfigNode.swift
@@ -16,21 +16,21 @@ public enum MockerProxyConfigKey {
 /// - SeeAlso:
 ///     - `MetadataConnectorNode`
 ///     - `RequestRouterNode`
-final class MockerProxyConfigNode<Raw, Output>: Node {
+open class MockerProxyConfigNode<Raw, Output>: Node {
 
     private typealias Keys = MockerProxyConfigKey
 
     // MARK: - Public Properties
 
     /// Следующий в цепочке узел.
-    public var next: any Node<RequestModel<Raw>, Output>
+    open var next: any Node<RequestModel<Raw>, Output>
 
     /// Указывает, включено ли проексирование.
-    public var isProxyingOn: Bool
+    open var isProxyingOn: Bool
     /// Адрес хоста (опционально с портом) которому будет переадресован запрос.
-    public var proxyingHost: String
+    open var proxyingHost: String
     /// Схема (http/https etc).
-    public var proxyingScheme: String
+    open var proxyingScheme: String
 
     // MARK: - Init
 
@@ -54,7 +54,7 @@ final class MockerProxyConfigNode<Raw, Output>: Node {
     // MARK: - Node
 
     /// Добавляет хедеры в `data`
-    public func process(_ data: RequestModel<Raw>) -> Observer<Output> {
+    open func process(_ data: RequestModel<Raw>) -> Observer<Output> {
 
         guard self.isProxyingOn else {
             return self.next.process(data)

--- a/NodeKit/Utils/Logging/LoggerNode.swift
+++ b/NodeKit/Utils/Logging/LoggerNode.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Этот узел выполняет выведение лога в консоль.
 /// Сразу же передает управление следующему узлу и подписывается на выполнение операций.
-open class LoggerNode<Input, Output>: Node<Input, Output> {
+open class LoggerNode<Input, Output>: Node {
     /// Следующий узел для обработки.
-    open var next: Node<Input, Output>
+    open var next: any Node<Input, Output>
     /// Содержит список ключей, по которым будет отфлитрован лог.
     open var filters: [String]
 
@@ -13,7 +13,7 @@ open class LoggerNode<Input, Output>: Node<Input, Output> {
     /// - Parameters:
     ///   - next: Следующий узел для обработки.
     ///   - filters: Содержит список ключей, по которым будет отфлитрован лог.
-    public init(next: Node<Input, Output>, filters: [String] = []) {
+    public init(next: any Node<Input, Output>, filters: [String] = []) {
         self.next = next
         self.filters = filters
     }
@@ -21,7 +21,7 @@ open class LoggerNode<Input, Output>: Node<Input, Output> {
     /// Сразу же передает управление следующему узлу и подписывается на выполнение операций.
     ///
     /// - Parameter data: Данные для обработки. Этот узел их не импользует.
-    open override func process(_ data: Input) -> Observer<Output> {
+    open func process(_ data: Input) -> Observer<Output> {
         let result = Context<Output>()
 
         let context = self.next.process(data)

--- a/NodeKit/Utils/Logging/LoggingContext.swift
+++ b/NodeKit/Utils/Logging/LoggingContext.swift
@@ -1,0 +1,49 @@
+//
+//  LoggingContext.swift
+//  NodeKit
+//
+//  Created by frolov on 19.03.2024.
+//  Copyright © 2024 Surf. All rights reserved.
+//
+
+import Foundation
+
+protocol LoggingContextProtocol: Actor {
+    // Лог контекста
+    var log: Logable? { get }
+    
+    /// Добавляет лог-сообщение к контексту.
+    /// - Parameter log: лог-сообщение.
+    func add(_ log: Logable?)
+}
+
+actor LoggingContext: LoggingContextProtocol {
+    
+    // Лог контекста
+    public private(set) var log: Logable?
+    
+    /// Добавляет лог-сообщение к контексту.
+    /// В случае, если у контекста не было лога, то он появится.
+    /// В случае, если у контекста был лог, но у него не было следующего, то этот добавится в качестве следующего лога.
+    /// В случае, если лог был, а у него был следующий лог, то этот будет вставлен между ними.
+    ///
+    /// - Parameter log: лог-сообщение.
+    public func add(_ log: Logable?) {
+        guard var selfLog = self.log else {
+            self.log = log
+            return
+        }
+
+        if selfLog.next == nil {
+            selfLog.next = log
+        } else {
+            var temp = log
+            temp?.next = selfLog.next
+            selfLog.next = temp
+        }
+
+        self.log = selfLog
+        return
+    }
+    
+}

--- a/NodeKit/Utils/Logging/LoggingContext.swift
+++ b/NodeKit/Utils/Logging/LoggingContext.swift
@@ -29,20 +29,20 @@ actor LoggingContext: LoggingContextProtocol {
     ///
     /// - Parameter log: лог-сообщение.
     public func add(_ log: Logable?) {
-        guard var selfLog = self.log else {
+        guard var currentLog = self.log else {
             self.log = log
             return
         }
 
-        if selfLog.next == nil {
-            selfLog.next = log
+        if currentLog.next == nil {
+            currentLog.next = log
         } else {
             var temp = log
-            temp?.next = selfLog.next
-            selfLog.next = temp
+            temp?.next = currentLog.next
+            currentLog.next = temp
         }
 
-        self.log = selfLog
+        self.log = currentLog
         return
     }
 

--- a/NodeKit/Utils/Logging/LoggingContext.swift
+++ b/NodeKit/Utils/Logging/LoggingContext.swift
@@ -11,17 +11,17 @@ import Foundation
 protocol LoggingContextProtocol: Actor {
     // Лог контекста
     var log: Logable? { get }
-    
+
     /// Добавляет лог-сообщение к контексту.
     /// - Parameter log: лог-сообщение.
     func add(_ log: Logable?)
 }
 
 actor LoggingContext: LoggingContextProtocol {
-    
+
     // Лог контекста
     public private(set) var log: Logable?
-    
+
     /// Добавляет лог-сообщение к контексту.
     /// В случае, если у контекста не было лога, то он появится.
     /// В случае, если у контекста был лог, но у него не было следующего, то этот добавится в качестве следующего лога.
@@ -45,5 +45,5 @@ actor LoggingContext: LoggingContextProtocol {
         self.log = selfLog
         return
     }
-    
+
 }

--- a/NodeKitTests/UnitTests/AborterNode/AbortingTests.swift
+++ b/NodeKitTests/UnitTests/AborterNode/AbortingTests.swift
@@ -15,11 +15,11 @@ import NodeKit
 public class AbortingTests: XCTestCase {
 
 
-    class MockAborter: Node<Void, Void>, Aborter {
+    class MockAborter: Node, Aborter {
 
         var cancelCallsNumber = 0
 
-        override func process(_ data: Void) -> Context<Void> {
+        func process(_ data: Void) -> Observer<Void> {
             let context = Context<Void>()
 
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(4)) {

--- a/NodeKitTests/UnitTests/CacheNode/ETag/UrlETagReaderNodeTests.swift
+++ b/NodeKitTests/UnitTests/CacheNode/ETag/UrlETagReaderNodeTests.swift
@@ -14,13 +14,13 @@ import NodeKit
 
 public class UrlETagReaderNodeTests: XCTestCase {
 
-    class MockNode: TransportLayerNode {
+    class MockNode: Node {
 
         var tag: String? = nil
 
         var key = ETagConstants.eTagRequestHeaderKey
 
-        override func process(_ data: TransportUrlRequest) -> Observer<Json> {
+        func process(_ data: TransportUrlRequest) -> Observer<Json> {
             tag = data.headers[self.key]
 
             return .emit(data: Json())

--- a/NodeKitTests/UnitTests/CacheNode/ETag/UrlETagUrlCacheTriggerNodeTests.swift
+++ b/NodeKitTests/UnitTests/CacheNode/ETag/UrlETagUrlCacheTriggerNodeTests.swift
@@ -14,21 +14,21 @@ import NodeKit
 
 public class UrlETagUrlCacheTriggerNodeTests: XCTestCase {
 
-    class TransportMock: ResponseProcessingLayerNode {
+    class TransportMock: Node {
 
         var numberOfCalls = 0
 
-        override func process(_ data: UrlDataResponse) -> Observer<Json> {
+        func process(_ data: UrlDataResponse) -> Observer<Json> {
             self.numberOfCalls += 1
             return .emit(data: Json())
         }
     }
 
-    class CacheSaverMock: Node<UrlNetworkRequest, Json> {
+    class CacheSaverMock: Node {
 
         var numberOfCalls = 0
 
-        override func process(_ data: UrlNetworkRequest) -> Observer<Json> {
+        func process(_ data: UrlNetworkRequest) -> Observer<Json> {
 
             self.numberOfCalls += 1
 

--- a/NodeKitTests/UnitTests/CacheNode/FirstCachePolicyTests.swift
+++ b/NodeKitTests/UnitTests/CacheNode/FirstCachePolicyTests.swift
@@ -14,11 +14,11 @@ import NodeKit
 
 public class FirstCachePolicyTests: XCTestCase {
 
-    private class NextStub: Node<RawUrlRequest, Json> {
+    private class NextStub: Node {
 
         var numberOfCalls = 0
 
-        override func process(_ data: RawUrlRequest) -> Observer<Json> {
+        func process(_ data: RawUrlRequest) -> Observer<Json> {
             self.numberOfCalls += 1
 
             let result = Context<Json>()
@@ -29,11 +29,11 @@ public class FirstCachePolicyTests: XCTestCase {
         }
     }
 
-    class ReaderStub: Node<UrlNetworkRequest, Json> {
+    class ReaderStub: Node {
 
         var numberOfCalls = 0
 
-        override func process(_ data: UrlNetworkRequest) -> Observer<Json> {
+        func process(_ data: UrlNetworkRequest) -> Observer<Json> {
 
             self.numberOfCalls += 1
 

--- a/NodeKitTests/UnitTests/CacheNode/IfConnectionFailedFromCacheNodeTests.swift
+++ b/NodeKitTests/UnitTests/CacheNode/IfConnectionFailedFromCacheNodeTests.swift
@@ -14,7 +14,7 @@ import NodeKit
 
 public class IfConnectionFailedFromCacheNodeTests: XCTestCase {
 
-    private class NextStub: Node<URLRequest, Json> {
+    private class NextStub: Node {
 
         var numberOfCalls: Int
         var lambda: () -> Observer<Json>
@@ -24,18 +24,18 @@ public class IfConnectionFailedFromCacheNodeTests: XCTestCase {
             self.numberOfCalls = 0
         }
 
-        override func process(_ data: URLRequest) -> Observer<Json> {
+        func process(_ data: URLRequest) -> Observer<Json> {
             self.numberOfCalls += 1
 
             return self.lambda()
         }
     }
 
-    class ReaderStub: Node<UrlNetworkRequest, Json> {
+    class ReaderStub: Node {
 
         var numberOfCalls = 0
 
-        override func process(_ data: UrlNetworkRequest) -> Observer<Json> {
+        func process(_ data: UrlNetworkRequest) -> Observer<Json> {
 
             self.numberOfCalls += 1
 

--- a/NodeKitTests/UnitTests/Coding/EncodingTests.swift
+++ b/NodeKitTests/UnitTests/Coding/EncodingTests.swift
@@ -13,12 +13,12 @@ import NodeKit
 
 public class EncodingTests: XCTestCase {
 
-    class StubNext: RequestProcessingLayerNode {
+    class StubNext: Node {
 
         var request: URLRequest! = nil
 
         @discardableResult
-        public override func process(_ data: URLRequest) -> Observer<Json> {
+        public func process(_ data: URLRequest) -> Observer<Json> {
             self.request = data
             return .emit(data: Json())
         }

--- a/NodeKitTests/UnitTests/DTO/DTOMapperNodeTests.swift
+++ b/NodeKitTests/UnitTests/DTO/DTOMapperNodeTests.swift
@@ -14,7 +14,7 @@ import NodeKit
 
 class DTOMapperNodeTests: XCTestCase {
     
-    class StubNode: Node<Json, Json> {
+    class StubNode: Node {
         let json: Json
         let resultError: Error?
         
@@ -24,7 +24,7 @@ class DTOMapperNodeTests: XCTestCase {
         }
         
         @discardableResult
-        public override func process(_ data: Json) -> Observer<Json> {
+        public func process(_ data: Json) -> Observer<Json> {
             if let error = resultError {
                 var log = Log(self.logViewObjectName, id: self.objectName, order: LogOrder.dtoMapperNode)
                 log += "\(error)"

--- a/NodeKitTests/UnitTests/InputLayer/ChainConfiguratorNodeTests.swift
+++ b/NodeKitTests/UnitTests/InputLayer/ChainConfiguratorNodeTests.swift
@@ -23,11 +23,11 @@ extension DispatchQueue {
 public class ChainConfiguratorNodeTests: XCTestCase {
 
 
-    class NextStub: Node<Void, Void> {
+    class NextStub: Node {
 
         var queueLabel = ""
 
-        override func process(_ data: Void) -> Observer<Void> {
+        func process(_ data: Void) -> Observer<Void> {
             self.queueLabel = DispatchQueue.currentLabel
             return .emit(data: data)
         }

--- a/NodeKitTests/UnitTests/MockerIntegration/MockerProxyConfigNodeTests.swift
+++ b/NodeKitTests/UnitTests/MockerIntegration/MockerProxyConfigNodeTests.swift
@@ -4,9 +4,9 @@ import XCTest
 public class MockerProxyConfigNodeTests: XCTestCase {
 
 
-    private class StubNode: Node<RequestModel<Int>, RequestModel<Int>> {
+    private class StubNode: Node {
 
-        override func process(_ data: RequestModel<Int>) -> Observer<RequestModel<Int>> {
+        func process(_ data: RequestModel<Int>) -> Observer<RequestModel<Int>> {
             return .emit(data: data)
         }
     }

--- a/NodeKitTests/UnitTests/RequestBuildingLayer/URLQueryInjectorNodeTests.swift
+++ b/NodeKitTests/UnitTests/RequestBuildingLayer/URLQueryInjectorNodeTests.swift
@@ -9,8 +9,8 @@ public class URLQueryInjectorNodeTests: XCTestCase {
 
     typealias Model = RoutableRequestModel<UrlRouteProvider, Json>
 
-    class StubNode: Node<Model, Model> {
-        override func process(_ data: Model) -> Observer<Model> {
+    class StubNode: Node {
+        func process(_ data: Model) -> Observer<Model> {
             return .emit(data: data)
         }
     }

--- a/NodeKitTests/UnitTests/TokenRefresher/TokenRefresherNodeTests.swift
+++ b/NodeKitTests/UnitTests/TokenRefresher/TokenRefresherNodeTests.swift
@@ -14,11 +14,11 @@ import NodeKit
 
 public class TokenRefresherNodeTests: XCTestCase {
 
-    class NodeStub: Node<Void, Void> {
+    class NodeStub: Node {
 
         var countOfCals = 0
 
-        override func process(_ data: Void) -> Observer<Void> {
+        func process(_ data: Void) -> Observer<Void> {
 
             let result = Context<Void>()
 

--- a/NodeKitTests/Utils/Equatable/Log+Equatalbe.swift
+++ b/NodeKitTests/Utils/Equatable/Log+Equatalbe.swift
@@ -9,7 +9,7 @@
 @testable import NodeKit
 
 extension Log: Equatable {
-    
+
     public static func == (lhs: NodeKit.Log, rhs: NodeKit.Log) -> Bool {
         return lhs.message == rhs.message &&
             lhs.description == rhs.description &&
@@ -17,5 +17,5 @@ extension Log: Equatable {
             lhs.id == rhs.id &&
             lhs.order == rhs.order
     }
-    
+
 }

--- a/NodeKitTests/Utils/Equatable/Log+Equatalbe.swift
+++ b/NodeKitTests/Utils/Equatable/Log+Equatalbe.swift
@@ -1,0 +1,21 @@
+//
+//  Log+Equatalbe.swift
+//  NodeKitTests
+//
+//  Created by frolov on 19.03.2024.
+//  Copyright © 2024 Surf. All rights reserved.
+//
+
+@testable import NodeKit
+
+extension Log: Equatable {
+    
+    public static func == (lhs: NodeKit.Log, rhs: NodeKit.Log) -> Bool {
+        return lhs.message == rhs.message &&
+            lhs.description == rhs.description &&
+            lhs.delimeter == rhs.delimeter &&
+            lhs.id == rhs.id &&
+            lhs.order == rhs.order
+    }
+    
+}

--- a/NodeKitTests/Utils/LoggingContextTests.swift
+++ b/NodeKitTests/Utils/LoggingContextTests.swift
@@ -39,7 +39,7 @@ final class LoggingContextTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func testLog_whenOneItemAppending_therResultIsAppendedItem() async throws {
+    func testLog_whenOneItemAppending_thenResultIsAppendedItem() async throws {
         // given
 
         let testLog = Log("Test message", id: "Test id")

--- a/NodeKitTests/Utils/LoggingContextTests.swift
+++ b/NodeKitTests/Utils/LoggingContextTests.swift
@@ -1,0 +1,154 @@
+//
+//  LoggingContextTests.swift
+//  NodeKitTests
+//
+//  Created by frolov on 19.03.2024.
+//  Copyright © 2024 Surf. All rights reserved.
+//
+
+@testable import NodeKit
+import XCTest
+
+final class LoggingContextTests: XCTestCase {
+    
+    // MARK: - Sut
+    
+    private var sut: LoggingContext!
+    
+    // MARK: - Lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        sut = LoggingContext()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+    
+    // MARK: - Tests
+    
+    func testLog_whenNothingAppending_thenResultIsNil() async {
+        // when
+        
+        let result = await sut.log
+        
+        // then
+        
+        XCTAssertNil(result)
+    }
+    
+    func testLog_whenOneItemAppending_therResultIsAppendedItem() async throws {
+        // given
+        
+        let testLog = Log("Test message", id: "Test id")
+        
+        // when
+        
+        await sut.add(testLog)
+        
+        let log = await sut.log
+        let result = try XCTUnwrap(log as? Log)
+        
+        // then
+        
+        XCTAssertEqual(result, testLog)
+    }
+    
+    func testLog_whenTwoItemsAppending_thenResultIsFirstItemAndNextIsSecondItem() async throws {
+        // given
+        
+        let firstLog = Log("Test first message", id: "Test first id")
+        let secondLog = Log("Test second message", id: "Test second id")
+        
+        var expectedLog = firstLog
+        expectedLog.next = secondLog
+        
+        // when
+        
+        await sut.add(firstLog)
+        await sut.add(secondLog)
+        
+        let log = await sut.log
+        let result = try XCTUnwrap(log as? Log)
+        let resultNext = try XCTUnwrap(result.next as? Log)
+        
+        // then
+        
+        XCTAssertEqual(result, expectedLog)
+        XCTAssertEqual(resultNext, secondLog)
+        XCTAssertNil(resultNext.next)
+    }
+    
+    func testLog_whenThreeItemsAppending_thenResultIsFirstItemAndNextIsTree() async throws {
+        // given
+        
+        let firstLog = Log("Test first message", id: "Test first id")
+        let secondLog = Log("Test second message", id: "Test second id")
+        let thirdLog = Log("Test third message", id: "Test third id")
+        
+        var expectedLog = firstLog
+        var expectedThirdLog = thirdLog
+        
+        expectedThirdLog.next = secondLog
+        expectedLog.next = expectedThirdLog
+        
+        // when
+        
+        await sut.add(firstLog)
+        await sut.add(secondLog)
+        await sut.add(thirdLog)
+        
+        let log = await sut.log
+        let result = try XCTUnwrap((log) as? Log)
+        let firstNextResult = try XCTUnwrap(result.next as? Log)
+        let secondNextResult = try XCTUnwrap(firstNextResult.next as? Log)
+        
+        // then
+        
+        XCTAssertEqual(result, expectedLog)
+        XCTAssertEqual(firstNextResult, expectedThirdLog)
+        XCTAssertEqual(secondNextResult, secondLog)
+        XCTAssertNil(secondNextResult.next)
+    }
+    
+    func testLog_whenFourItemsAppending_thenResultIsFirstItemAndNextIsTree() async throws {
+        // given
+        
+        let firstLog = Log("Test first message", id: "Test first id")
+        let secondLog = Log("Test second message", id: "Test second id")
+        let thirdLog = Log("Test third message", id: "Test third id")
+        let fourthLog = Log("Test fourth message", id: "Test fourth id")
+        
+        var expectedLog = firstLog
+        var expectedFourthLog = fourthLog
+        var expectedThirdLog = thirdLog
+        
+        expectedThirdLog.next = secondLog
+        expectedFourthLog.next = expectedThirdLog
+        expectedLog.next = expectedFourthLog
+        
+        // when
+        
+        await sut.add(firstLog)
+        await sut.add(secondLog)
+        await sut.add(thirdLog)
+        await sut.add(fourthLog)
+        
+        let log = await sut.log
+        let result = try XCTUnwrap(log as? Log)
+        let firstNextResult = try XCTUnwrap(result.next as? Log)
+        let secondNextResult = try XCTUnwrap(firstNextResult.next as? Log)
+        let thirdNextResult = try XCTUnwrap(secondNextResult.next as? Log)
+        
+        // then
+        
+        XCTAssertEqual(result, expectedLog)
+        XCTAssertEqual(firstNextResult, expectedFourthLog)
+        XCTAssertEqual(secondNextResult, expectedThirdLog)
+        XCTAssertEqual(thirdNextResult, secondLog)
+        XCTAssertNil(thirdNextResult.next)
+    }
+    
+}

--- a/NodeKitTests/Utils/LoggingContextTests.swift
+++ b/NodeKitTests/Utils/LoggingContextTests.swift
@@ -10,103 +10,103 @@
 import XCTest
 
 final class LoggingContextTests: XCTestCase {
-    
+
     // MARK: - Sut
-    
+
     private var sut: LoggingContext!
-    
+
     // MARK: - Lifecycle
-    
+
     override func setUp() {
         super.setUp()
         sut = LoggingContext()
     }
-    
+
     override func tearDown() {
         super.tearDown()
         sut = nil
     }
-    
+
     // MARK: - Tests
-    
+
     func testLog_whenNothingAppending_thenResultIsNil() async {
         // when
-        
+
         let result = await sut.log
-        
+
         // then
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testLog_whenOneItemAppending_therResultIsAppendedItem() async throws {
         // given
-        
+
         let testLog = Log("Test message", id: "Test id")
-        
+
         // when
-        
+
         await sut.add(testLog)
-        
+
         let log = await sut.log
         let result = try XCTUnwrap(log as? Log)
-        
+
         // then
-        
+
         XCTAssertEqual(result, testLog)
     }
-    
+
     func testLog_whenTwoItemsAppending_thenResultIsFirstItemAndNextIsSecondItem() async throws {
         // given
-        
+
         let firstLog = Log("Test first message", id: "Test first id")
         let secondLog = Log("Test second message", id: "Test second id")
-        
+
         var expectedLog = firstLog
         expectedLog.next = secondLog
-        
+
         // when
-        
+
         await sut.add(firstLog)
         await sut.add(secondLog)
-        
+
         let log = await sut.log
         let result = try XCTUnwrap(log as? Log)
         let resultNext = try XCTUnwrap(result.next as? Log)
-        
+
         // then
-        
+
         XCTAssertEqual(result, expectedLog)
         XCTAssertEqual(resultNext, secondLog)
         XCTAssertNil(resultNext.next)
     }
-    
+
     func testLog_whenThreeItemsAppending_thenResultIsFirstItemAndNextIsTree() async throws {
         // given
-        
+
         let firstLog = Log("Test first message", id: "Test first id")
         let secondLog = Log("Test second message", id: "Test second id")
         let thirdLog = Log("Test third message", id: "Test third id")
-        
+
         var expectedLog = firstLog
         var expectedThirdLog = thirdLog
-        
+
         expectedThirdLog.next = secondLog
         expectedLog.next = expectedThirdLog
-        
+
         // when
-        
+
         await sut.add(firstLog)
         await sut.add(secondLog)
         await sut.add(thirdLog)
-        
+
         let log = await sut.log
         let result = try XCTUnwrap((log) as? Log)
         let firstNextResult = try XCTUnwrap(result.next as? Log)
         let secondNextResult = try XCTUnwrap(firstNextResult.next as? Log)
-        
+
         // then
-        
+
         XCTAssertEqual(result, expectedLog)
         XCTAssertEqual(firstNextResult, expectedThirdLog)
         XCTAssertEqual(secondNextResult, secondLog)
@@ -115,40 +115,40 @@ final class LoggingContextTests: XCTestCase {
     
     func testLog_whenFourItemsAppending_thenResultIsFirstItemAndNextIsTree() async throws {
         // given
-        
+
         let firstLog = Log("Test first message", id: "Test first id")
         let secondLog = Log("Test second message", id: "Test second id")
         let thirdLog = Log("Test third message", id: "Test third id")
         let fourthLog = Log("Test fourth message", id: "Test fourth id")
-        
+
         var expectedLog = firstLog
         var expectedFourthLog = fourthLog
         var expectedThirdLog = thirdLog
-        
+
         expectedThirdLog.next = secondLog
         expectedFourthLog.next = expectedThirdLog
         expectedLog.next = expectedFourthLog
-        
+
         // when
-        
+
         await sut.add(firstLog)
         await sut.add(secondLog)
         await sut.add(thirdLog)
         await sut.add(fourthLog)
-        
+
         let log = await sut.log
         let result = try XCTUnwrap(log as? Log)
         let firstNextResult = try XCTUnwrap(result.next as? Log)
         let secondNextResult = try XCTUnwrap(firstNextResult.next as? Log)
         let thirdNextResult = try XCTUnwrap(secondNextResult.next as? Log)
-        
+
         // then
-        
+
         XCTAssertEqual(result, expectedLog)
         XCTAssertEqual(firstNextResult, expectedFourthLog)
         XCTAssertEqual(secondNextResult, expectedThirdLog)
         XCTAssertEqual(thirdNextResult, secondLog)
         XCTAssertNil(thirdNextResult.next)
     }
-    
+
 }

--- a/NodeKitTests/Utils/LoggingContextTests.swift
+++ b/NodeKitTests/Utils/LoggingContextTests.swift
@@ -81,6 +81,8 @@ final class LoggingContextTests: XCTestCase {
         XCTAssertNil(resultNext.next)
     }
 
+    /// Элементы в лог вставляются не в конец, а в начало списка, при этом первый лог не меняется.
+    /// При добавлении Log3 в список Log1 -> Log2, получается новый список Log1 -> Log3 -> Log2
     func testLog_whenThreeItemsAppending_thenResultIsFirstItemAndNextIsTree() async throws {
         // given
 


### PR DESCRIPTION
# What is done

- Улучшены generic в протоколах
- Убран базовый класс Node, протокол NodeProtocol переименован в Node
- Создан LoggingContext для записи логов внутри нод

Так как для записи логов в async методах не используется Observer, который хранит логи, создал LoggingContext и перенес логику логов туда. В async методах нодов LoggingContext будет хранить логи с узлов, а LoggerNode разгребать его.